### PR TITLE
CLI output is saved to variable called output

### DIFF
--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,3 +1,7 @@
 #!/bin/sh -l
 
-sh -c "if grep \"^ignore:$BUILD_DIR\" $HOME/ignore; then ls $HOME && exit 0; else ${BUILD_COMMAND:-echo} && netlify $*; fi"
+if grep "^ignore:$BUILD_DIR" $HOME/ignore; then
+ ls $HOME && exit 0;
+else 
+ ${BUILD_COMMAND:-echo} && output=$(netlify $*); echo ::set-output name=output::$output;
+fi


### PR DESCRIPTION
CLI output is saved to variable called output

This allows the output of the netlify command to be used in subsequent actions.

### Example
```
name: CI

on: [push]

jobs:
  build:

    runs-on: ubuntu-latest
    
    timeout-minutes: 10
    
    steps:
    - uses: actions/checkout@master
    
    - name: Deploy to Netlify
      id: netlify
      uses: ivanjosipovic/actions/cli@master
      with:
        args: deploy --json -d .
      env:
        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
        
    - name: Get Deploy Url
      run: |
        $url = $(ConvertFrom-Json '${{ steps.netlify.outputs.output }}').deploy_url;
        Write-Output $url;
      shell: pwsh

```