### PR TITLE
Upgrade node alpine version to 12.x for open api compatibility

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 LABEL version="1.0.0"
 LABEL repository="http://github.com/netlify/actions"


### PR DESCRIPTION
The recently upgraded version of open api was creating an error :

error @netlify/open-api@0.13.0: The engine "node" is incompatible with this module. Expected version "12". Got "10.19.0"

Here is a PR to upgrade to the latest LTS of node (12). That fixes the problem.