### PR TITLE
[Features] Output available as environment. URL are as separate variables

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
 LABEL version="1.0.0"
 LABEL repository="http://github.com/netlify/actions"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -1,7 +1,21 @@
 #!/bin/sh -l
 
-if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
-  echo "$BUILD_DIR didn't change"
-else
-  ${BUILD_COMMAND:-echo} && netlify $*
-fi
+read -d '' COMMAND <<- EOF
+  if [ -f "$HOME/ignore" ] && grep "^ignore:$BUILD_DIR" "$HOME/ignore"; then
+    echo "$BUILD_DIR didn't change"
+  else
+    ${BUILD_COMMAND:-echo} && netlify $*
+  fi
+EOF
+
+OUTPUT=$(sh -c "$COMMAND")
+
+NETLIFY_OUTPUT=$(echo "$OUTPUT")
+NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
+NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://(?!netlify.com)[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
+
+echo "::set-output name=NETLIFY_OUTPUT::$NETLIFY_OUTPUT"
+echo "::set-output name=NETLIFY_URL::$NETLIFY_URL"
+echo "::set-output name=NETLIFY_LOGS_URL::$NETLIFY_LOGS_URL"
+echo "::set-output name=NETLIFY_LIVE_URL::$NETLIFY_LIVE_URL"

--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -13,7 +13,7 @@ OUTPUT=$(sh -c "$COMMAND")
 NETLIFY_OUTPUT=$(echo "$OUTPUT")
 NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
-NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://(?!netlify.com)[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
+NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
 echo "::set-output name=NETLIFY_OUTPUT::$NETLIFY_OUTPUT"
 echo "::set-output name=NETLIFY_URL::$NETLIFY_URL"


### PR DESCRIPTION
I propose better solution to handle output from action.
I use 4 variable:

NETLIFY_OUTPUT - full code to pipe in other jobs
NETLIFY_URL - this is url to get deploy preview from container to other jobs as linkable field
NETLIFY_LOGS_URL - same like above but for logs file
NETLIFY_LIVE_URL - this not only work as same as above but if empty then can be used conditional

Thanks to:
#21 - test node version v12
#16 - main part of solution where I use main variable

Part of solution for:
#14 - only main branch this time can be used