### PR TITLE
Fix deploy

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:10-alpine
+FROM node:12-alpine
 
-LABEL version="1.0.0"
+LABEL version="1.0.1"
 LABEL repository="http://github.com/netlify/actions"
 LABEL homepage="http://github.com/netlify/actions/netlify"
 LABEL maintainer="Netlify"


### PR DESCRIPTION
```
error @netlify/open-api@0.13.0: The engine "node" is incompatible with this module. Expected version "12". Got "10.19.0"
```