### PR TITLE
Correct example in documentation for cli action

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -22,8 +22,8 @@ jobs:
 
     - name: Publish
       uses: netlify/actions/cli@master
-        with:
-          args: deploy --dir=site --functions=functions
+      with:
+        args: deploy --dir=site --functions=functions
       env:
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
The example for cli usage in README.md is not correct with wrong indent

```yml
    - name: Publish
      uses: netlify/actions/cli@maste
        with:	
          args: deploy --dir=site --functions=functions	
      env:
        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }
        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
```

Fix to
```yml
    - name: Publish
      uses: netlify/actions/cli@master
      with:
        args: deploy --dir=site --functions=functions
      env:
        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
```
