### PR TITLE
diff-includes should return an exit

### DIFF
--- a/diff-includes/entrypoint.sh
+++ b/diff-includes/entrypoint.sh
@@ -4,5 +4,6 @@
 if ! git diff-index --quiet HEAD~$(jq '.commits | length' "${GITHUB_EVENT_PATH}") $*; then
   echo "Changes in $*, proceeding"
 else
-  echo "No changes in $*, stopping" && echo "ignore:$*" >> "$HOME/ignore"
+  echo "No changes in $*, stopping" && echo exit 1;
+  # echo "No changes in $*, stopping" && echo "ignore:$*" >> "$HOME/ignore"
 fi

--- a/diff-includes/entrypoint.sh
+++ b/diff-includes/entrypoint.sh
@@ -4,6 +4,6 @@
 if ! git diff-index --quiet HEAD~$(jq '.commits | length' "${GITHUB_EVENT_PATH}") $*; then
   echo "Changes in $*, proceeding"
 else
-  echo "No changes in $*, stopping" && echo exit 1;
+  echo "No changes in $*, stopping" && exit 1;
   # echo "No changes in $*, stopping" && echo "ignore:$*" >> "$HOME/ignore"
 fi


### PR DESCRIPTION
Diff-includes only echos output before this commit. This commit returns an exit which automatically stops other jobs that needs it from the workflow.