### PR TITLE
Resolve broken GitHub action by bumping CLI

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 LABEL version="1.0.1"
 LABEL repository="http://github.com/netlify/actions"


### PR DESCRIPTION
```
  yarn global v1.22.5
42
  [1/4] Resolving packages...
43
  warning netlify-cli > copy-template-dir > readdirp > micromatch > snapdragon > source-map-resolve > resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
44
  warning netlify-cli > copy-template-dir > readdirp > micromatch > snapdragon > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
45
  warning netlify-cli > @netlify/build > @netlify/plugin-edge-handlers > rollup-plugin-node-builtins > browserify-fs > level-filesystem > level-sublevel > xtend > object-keys@0.2.0: Please update to the latest object-keys
46
  [2/4] Fetching packages...
47
  info fsevents@2.1.3: The platform "linux" is incompatible with this module.
48
  info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
49
  error terser@5.3.6: The engine "node" is incompatible with this module. Expected version "^10.0.0,^11.0.0,^12.0.0,>=14.0.0". Got "12.19.0"
50
  error Found incompatible module.
51
  info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
52
  The command '/bin/sh -c yarn global add netlify-cli' returned a non-zero code: 1
```