### PR TITLE
fix(cli): Change yarn install to npm install

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -9,7 +9,7 @@ LABEL "com.github.actions.description"="Wraps the Netlify CLI to enable common N
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="blue"
 
-RUN yarn global add netlify-cli
+RUN npm install -g netlify-cli
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Resolve https://github.com/netlify/actions/issues/54

## Why
The colors.js used in netlify-cli has been broken. This is because the author of colors.js was angry that he wasn't being paid, so he added an infinite loop process and released it.  `netlify-cli` addressed this issue, but it was a fix based on the assumption that npm was being used.

> As a workaround please use npm install -g netlify-cli. We publish a shrinkfile file with the CLI that prevents such issues by locking the CLI dependencies during publish time, however yarn doesn't support it, hence it takes the latest (and broken) version of colors.js.
Ref https://github.com/netlify/cli/issues/3981#issuecomment-1008368062

## What
Changed yarn install without Docker file to npm install