### PR TITLE
Update Dockerfile for node 14

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:14-alpine
 
 LABEL version="1.0.1"
 LABEL repository="http://github.com/netlify/actions"


### PR DESCRIPTION
Node 12 is no longer supported for deploy in Netlify. This PR makes the upgrade to Node 14