### PR TITLE
fix(cli): remove cli warning due to command deprecation

### DIFF
--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -10,12 +10,14 @@ EOF
 
 OUTPUT=$(sh -c "$COMMAND")
 
-NETLIFY_OUTPUT=$(echo "$OUTPUT")
 NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*') #Unique key: --
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-echo "::set-output name=NETLIFY_OUTPUT::$NETLIFY_OUTPUT"
-echo "::set-output name=NETLIFY_URL::$NETLIFY_URL"
-echo "::set-output name=NETLIFY_LOGS_URL::$NETLIFY_LOGS_URL"
-echo "::set-output name=NETLIFY_LIVE_URL::$NETLIFY_LIVE_URL"
+echo "NETLIFY_LIVE_URL=$NETLIFY_LIVE_URL" >> $GITHUB_OUTPUT
+echo "NETLIFY_LOGS_URL=$NETLIFY_LOGS_URL" >> $GITHUB_OUTPUT
+echo "NETLIFY_URL=$NETLIFY_URL" >> $GITHUB_OUTPUT
+
+echo "NETLIFY_OUTPUT<<EOF" >> $GITHUB_OUTPUT
+echo "$OUTPUT" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub recently deprecated the `set-output` command and replace it with an environment file. This cause a lot of warning in actions log and even worse after the 31st May 2023 since the action will simply crash.   
For more information, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

| Before | After |
|-----------|---------|
| ![2022-11-27_14-30](https://user-images.githubusercontent.com/68606322/204137997-5d0bc292-ba3a-47f5-94f9-7718fb3663a1.png) | ![2022-11-27_14-30_1](https://user-images.githubusercontent.com/68606322/204138001-d3e8853d-7350-4381-9220-a0cdb065babc.png)|


