### PR TITLE
Update deprecated Github Actions set-output command

### DIFF
--- a/cli/entrypoint.sh
+++ b/cli/entrypoint.sh
@@ -15,7 +15,7 @@ NETLIFY_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a
 NETLIFY_LOGS_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://app.netlify.com/[a-zA-Z0-9./?=_-]*') #Unique key: app.netlify.com
 NETLIFY_LIVE_URL=$(echo "$OUTPUT" | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*' | grep -Eov "netlify.com") #Unique key: don't containr -- and app.netlify.com
 
-echo "::set-output name=NETLIFY_OUTPUT::$NETLIFY_OUTPUT"
-echo "::set-output name=NETLIFY_URL::$NETLIFY_URL"
-echo "::set-output name=NETLIFY_LOGS_URL::$NETLIFY_LOGS_URL"
-echo "::set-output name=NETLIFY_LIVE_URL::$NETLIFY_LIVE_URL"
+echo "{NETLIFY_OUTPUT}={$NETLIFY_OUTPUT}" >> $GITHUB_OUTPUT
+echo "{NETLIFY_URL}={$NETLIFY_URL}" >> $GITHUB_OUTPUT
+echo "{NETLIFY_LOGS_URL}={$NETLIFY_LOGS_URL}" >> $GITHUB_OUTPUT
+echo "{NETLIFY_LIVE_URL}={$NETLIFY_LIVE_URL}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)