### PR TITLE
Update to Node 22

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:16-alpine
+FROM node:22-alpine
 
-LABEL version="1.0.3"
+LABEL version="1.0.4"
 LABEL repository="http://github.com/netlify/actions"
 LABEL homepage="http://github.com/netlify/actions/netlify"
 LABEL maintainer="Netlify"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -9,6 +9,9 @@ LABEL "com.github.actions.description"="Wraps the Netlify CLI to enable common N
 LABEL "com.github.actions.icon"="cloud"
 LABEL "com.github.actions.color"="blue"
 
+# Install bash and other required dependencies
+RUN apk add --no-cache bash
+
 RUN npm install -g netlify-cli
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the CLI to use a newer Node.js version and increments the version label.

Dockerfile updates:

* [`cli/Dockerfile`](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472L1-R3): Updated the base image from `node:16-alpine` to `node:22-alpine` to ensure compatibility with the latest Node.js features and security updates.
* [`cli/Dockerfile`](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472L1-R3): Incremented the version label from `1.0.3` to `1.0.4` to reflect the changes.